### PR TITLE
Use httpsnoop instead of a response wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/brunoga/deep v1.2.4
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/go-jose/go-jose/v4 v4.1.1
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=

--- a/pkg/server/middleware/capture.go
+++ b/pkg/server/middleware/capture.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/felixge/httpsnoop"
+)
+
+type Capture struct {
+	body *bytes.Buffer
+	code int
+}
+
+// NewCapture creates a ready-to-use Capture. You use it by calling `Wrap` on an `http.ResponseWriter`,
+// using the result in a handler, then examining the capture StatusCode() and Body().
+// The convenience `CaptureResponse(...)` below does the above given the http.Handler, and hands you
+// back the capture.
+func NewCapture() *Capture {
+	return &Capture{
+		body: &bytes.Buffer{},
+		code: http.StatusOK,
+	}
+}
+
+func (c *Capture) StatusCode() int {
+	return c.code
+}
+
+func (c *Capture) Body() *bytes.Buffer {
+	return c.body
+}
+
+// Wrap creates a http.ResponseWriter which will capture the response in the method receiver so it
+// can be examined after being used in a handler. Consider using `CaptureResponse()`, which does this
+// for you.
+func (c *Capture) Wrap(w http.ResponseWriter) http.ResponseWriter {
+	return httpsnoop.Wrap(w, httpsnoop.Hooks{
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(p []byte) (int, error) {
+				n, err := next(p)
+				c.body.Write(p[:n]) // this always succeeds, for bytes.Buffer (unless it panics!)
+
+				return n, err
+			}
+		},
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(statuscode int) {
+				c.code = statuscode
+				next(statuscode)
+			}
+		},
+		ReadFrom: func(next httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(src io.Reader) (int64, error) {
+				tee := io.TeeReader(src, c.body)
+				return next(tee)
+			}
+		},
+	})
+}
+
+// CaptureResponse runs the given http.Handler and returns the captured response.
+// To see headers, look at `w.Header()`, which will be mutated by the handler.
+func CaptureResponse(w http.ResponseWriter, r *http.Request, next http.Handler) *Capture {
+	capture := NewCapture()
+	next.ServeHTTP(capture.Wrap(w), r)
+
+	return capture
+}

--- a/pkg/server/middleware/capture_test.go
+++ b/pkg/server/middleware/capture_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024-2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/core/pkg/server/middleware"
+)
+
+func TestResponseCapture(t *testing.T) {
+	t.Parallel()
+
+	testWithHandler := func(t *testing.T, handler http.Handler) {
+		t.Helper()
+
+		responserec := &ReadFromRecorder{ResponseRecorder: httptest.NewRecorder()}
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+		response := middleware.CaptureResponse(responserec, request, handler)
+
+		assert.Equal(t, http.StatusOK, response.StatusCode())
+		body, err := io.ReadAll(response.Body())
+		require.NoError(t, err)
+		assert.Equal(t, "OK", string(body))
+		t.Logf("ReadFrom called: %v", responserec.called)
+	}
+
+	t.Run("http.StatusOK OK with Write", func(t *testing.T) {
+		t.Parallel()
+
+		OKhandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Foo", "bar")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, "OK")
+		})
+		testWithHandler(t, OKhandler)
+	})
+
+	t.Run("implicit http.StatusOK OK", func(t *testing.T) {
+		t.Parallel()
+
+		implicitHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Foo", "bar")
+			_, _ = io.WriteString(w, "OK")
+		})
+		testWithHandler(t, implicitHandler)
+	})
+
+	// Some real world handlers might use io.Copy, which will in turn try to use ReadFrom() to be more efficient.
+	// The standard http.ResponseWriter implementation implements ReadFrom; implementing Write is enough for io.Copy to
+	// work, though. This just double-checks that if there _is_ an implementation of ReadFrom, it will also work
+	// as expected.
+	t.Run("io.Copy http.StatusOK OK", func(t *testing.T) {
+		t.Parallel()
+
+		iocopyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Foo", "bar")
+			w.WriteHeader(http.StatusOK)
+
+			body := bytes.NewBufferString("OK")
+			// io.Copy will use src.WriteTo in preference, and bytes.Buffer happens to implement it; so
+			// give it the chance to use ReadFrom first.
+			if readFrom, ok := w.(io.ReaderFrom); ok {
+				_, _ = readFrom.ReadFrom(body)
+			} else {
+				_, _ = io.Copy(w, body)
+			}
+		})
+		testWithHandler(t, iocopyHandler)
+	})
+
+	t.Run("multiwrite http.StatusOK OK", func(t *testing.T) {
+		t.Parallel()
+
+		multiwriteHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Foo", "bar")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, "O")
+			_, _ = io.WriteString(w, "K")
+		})
+		testWithHandler(t, multiwriteHandler)
+	})
+}
+
+type ReadFromRecorder struct {
+	called bool
+	*httptest.ResponseRecorder
+}
+
+// This may end up doing a buffered write, or using src.WriteTo; the point is that it's
+// there to be called.
+func (w *ReadFromRecorder) ReadFrom(src io.Reader) (int64, error) {
+	w.called = true
+	return io.Copy(w.ResponseRecorder, src)
+}

--- a/pkg/server/middleware/types_test.go
+++ b/pkg/server/middleware/types_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/unikorn-cloud/core/pkg/server/middleware"
+)
+
+func TestLoggingResponseWriter(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	lw := middleware.NewLoggingResponseWriter(w)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		lw.WriteHeader(http.StatusAccepted)
+		_, _ = io.WriteString(lw, "foo")
+		_, _ = io.WriteString(lw, "bar")
+	})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(lw, r)
+
+	assert.Equal(t, lw.StatusCode(), http.StatusAccepted)
+	assert.Equal(t, len("foo"+"bar"), lw.Body().Len())
+}


### PR DESCRIPTION
This PR makes two changes, both involving the use of httpsnoop for wrapping http.ResponseWriter.

The motivation behind both is that wrapping http.ResponseWriter is not quite as simple as implementing the methods of that interface. There are additional methods that can be implemented (and are, in the implementation in stdlib) which will be used by handlers if present. The situation is explained well here: https://github.com/felixge/httpsnoop/tree/v1.0.4?tab=readme-ov-file#why-this-package-exists.

The two changes are:

 - use `httpsnoop.CaptureMetrics` for the response wrapping in this repo; it does what we need here, so doesn't need our own code
 - add an abstraction and a convenience func for wrapping http.ResponseWriter for the purpose of capturing the response status code and body

The latter isn't a requirement of this repo, but it's needed in two different places in identity. The new abstraction does for both requirements there, and they could be ported to it.

I've reimplemented the existing `LoggingResponseWriter` using the general purpose response capture; it retains the drawbacks of the prior approach, and we should deprecate it, but for now I'm keeping it in so nothing breaks.
