### PR TITLE
Add Tag Lookup

### DIFF
--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -109,3 +109,16 @@ func (t TagList) ContainsAll(o TagList) bool {
 
 	return true
 }
+
+func (t TagList) Find(name string) (string, bool) {
+	predicate := func(tag Tag) bool {
+		return tag.Name == name
+	}
+
+	index := slices.IndexFunc(t, predicate)
+	if index < 0 {
+		return "", false
+	}
+
+	return t[index].Value, true
+}


### PR DESCRIPTION
Allows us to watch resources, then extract parent information from the tags e.g. compute clusters can watch servers and trigger a reconcile on server status update.